### PR TITLE
Initialize back-to-top visibility and clean config

### DIFF
--- a/src/components/BackToTop.vue
+++ b/src/components/BackToTop.vue
@@ -18,7 +18,10 @@ function handleScroll() {
   visible.value = window.scrollY > 300;
 }
 
-onMounted(() => window.addEventListener("scroll", handleScroll));
+onMounted(() => {
+  window.addEventListener("scroll", handleScroll);
+  handleScroll();
+});
 onUnmounted(() => window.removeEventListener("scroll", handleScroll));
 
 function scrollTop() {

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,6 +1,4 @@
 // vue.config.js
-const path = require("path");
-
 module.exports = {
   css: {
     loaderOptions: {


### PR DESCRIPTION
## Summary
- Initialize back-to-top button visibility on mount to reflect current scroll position
- Remove unused `path` import from `vue.config.js` to resolve lint error

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895b5e2fc50832fad2a8d1f3c5fb60a